### PR TITLE
ci: separate push and pr workflows

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,7 +1,5 @@
 name: CI
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -45,16 +43,12 @@ jobs:
           TRX_PATH: ${{ env.TRX_DIRECTORY }}
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BADGE_STYLE: emoji
-  build-test-analyze-debug:
+  build-test-debug:
     runs-on: windows-latest
     env:
       CONFIGURATION: Debug
       TRX_DIRECTORY: ./test/output/Debug
     steps:
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.11
       - name: Clone repository
         uses: actions/checkout@v3
         with:
@@ -64,36 +58,7 @@ jobs:
         with:
           github-packages: true
           github-username: ${{ github.actor }}
-          github-secret: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache SonarQube packages
-        uses: actions/cache@v1
-        with:
-          path: ~\sonar\cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache SonarQube scanner
-        id: cache-sonar-scanner
-        uses: actions/cache@v1
-        with:
-          path: .\.sonar\scanner
-          key: ${{ runner.os }}-sonar-scanner
-          restore-keys: ${{ runner.os }}-sonar-scanner
-      - name: Install SonarQube scanner
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
-        shell: powershell
-        run: |
-          New-Item -Path .\.sonar\scanner -ItemType Directory
-          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
-      - name: Start Analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        shell: powershell
-        run: >
-          .\.sonar\scanner\dotnet-sonarscanner begin
-          /k:"${{ secrets.SONAR_ID }}"
-          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
-          /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}"
-          /s:${{ github.workspace }}/SonarQube.Analysis.xml
+          github-secret: ${{ secrets.GITHUB_TOKEN }}     
       - name: Execute dotnet build
         run: >
           dotnet build .
@@ -107,13 +72,6 @@ jobs:
           --collect:"XPlat Code Coverage"
           --logger:trx
           --no-restore
-      - name: End Analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        shell: powershell
-        run: >
-          .\.sonar\scanner\dotnet-sonarscanner end 
-          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
       - name: Parse TRX File
         if: ${{ always() }}
         uses: solarisin/trx-parser@dev3

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,124 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+env:
+  CI_BUILD: true
+jobs:
+  build-test-release:
+    runs-on: ubuntu-latest
+    env:
+      CONFIGURATION: Release
+      TRX_DIRECTORY: ./test/output/Release
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarqube analysis
+      - name: Bootstrap dotnet dependencies
+        uses: ./.github/workflows/composite/bootstrap-dotnet
+        with:
+          github-packages: true
+          github-username: ${{ github.actor }}
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+      - name: Execute dotnet build
+        run: >
+          dotnet build .
+          --configuration ${{ env.CONFIGURATION }}
+      - name: Execute dotnet test
+        run: >
+          dotnet test .
+          --configuration ${{ env.CONFIGURATION }}
+          --results-directory ${{ env.TRX_DIRECTORY }}
+          --settings coverlet.runsettings
+          --collect:"XPlat Code Coverage"
+          --logger:trx
+          --no-restore
+      - name: Parse TRX File
+        if: ${{ always() }}
+        uses: solarisin/trx-parser@dev3
+        id: trx-parser
+        with:
+          TRX_PATH: ${{ env.TRX_DIRECTORY }}
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BADGE_STYLE: emoji
+  build-test-analyze-debug:
+    runs-on: windows-latest
+    env:
+      CONFIGURATION: Debug
+      TRX_DIRECTORY: ./test/output/Debug
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarqube analysis
+      - name: Bootstrap dotnet dependencies
+        uses: ./.github/workflows/composite/bootstrap-dotnet
+        with:
+          github-packages: true
+          github-username: ${{ github.actor }}
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache SonarQube packages
+        uses: actions/cache@v1
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache SonarQube scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v1
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+      - name: Install SonarQube scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          New-Item -Path .\.sonar\scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+      - name: Start Analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        shell: powershell
+        run: >
+          .\.sonar\scanner\dotnet-sonarscanner begin
+          /k:"${{ secrets.SONAR_ID }}"
+          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}"
+          /s:${{ github.workspace }}/SonarQube.Analysis.xml
+      - name: Execute dotnet build
+        run: >
+          dotnet build .
+          --configuration ${{ env.CONFIGURATION }}
+      - name: Execute dotnet test
+        run: >
+          dotnet test .
+          --configuration ${{ env.CONFIGURATION }}
+          --results-directory ${{ env.TRX_DIRECTORY }}
+          --settings coverlet.runsettings
+          --collect:"XPlat Code Coverage"
+          --logger:trx
+          --no-restore
+      - name: End Analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        shell: powershell
+        run: >
+          .\.sonar\scanner\dotnet-sonarscanner end 
+          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+      - name: Parse TRX File
+        if: ${{ always() }}
+        uses: solarisin/trx-parser@dev3
+        id: trx-parser
+        with:
+          TRX_PATH: ${{ env.TRX_DIRECTORY }}
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BADGE_STYLE: emoji

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: CI
+name: ci-pr
 on:
   pull_request:
     branches: [ main ]

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,8 +1,6 @@
-name: CI
+name: ci-push
 on:
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
   workflow_dispatch:
 env:

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,124 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+env:
+  CI_BUILD: true
+jobs:
+  build-test-release:
+    runs-on: ubuntu-latest
+    env:
+      CONFIGURATION: Release
+      TRX_DIRECTORY: ./test/output/Release
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarqube analysis
+      - name: Bootstrap dotnet dependencies
+        uses: ./.github/workflows/composite/bootstrap-dotnet
+        with:
+          github-packages: true
+          github-username: ${{ github.actor }}
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+      - name: Execute dotnet build
+        run: >
+          dotnet build .
+          --configuration ${{ env.CONFIGURATION }}
+      - name: Execute dotnet test
+        run: >
+          dotnet test .
+          --configuration ${{ env.CONFIGURATION }}
+          --results-directory ${{ env.TRX_DIRECTORY }}
+          --settings coverlet.runsettings
+          --collect:"XPlat Code Coverage"
+          --logger:trx
+          --no-restore
+      - name: Parse TRX File
+        if: ${{ always() }}
+        uses: solarisin/trx-parser@dev3
+        id: trx-parser
+        with:
+          TRX_PATH: ${{ env.TRX_DIRECTORY }}
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BADGE_STYLE: emoji
+  build-test-analyze-debug:
+    runs-on: windows-latest
+    env:
+      CONFIGURATION: Debug
+      TRX_DIRECTORY: ./test/output/Debug
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarqube analysis
+      - name: Bootstrap dotnet dependencies
+        uses: ./.github/workflows/composite/bootstrap-dotnet
+        with:
+          github-packages: true
+          github-username: ${{ github.actor }}
+          github-secret: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache SonarQube packages
+        uses: actions/cache@v1
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache SonarQube scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v1
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+      - name: Install SonarQube scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          New-Item -Path .\.sonar\scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+      - name: Start Analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        shell: powershell
+        run: >
+          .\.sonar\scanner\dotnet-sonarscanner begin
+          /k:"${{ secrets.SONAR_ID }}"
+          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+          /d:sonar.host.url="${{ secrets.SONAR_HOST_URL }}"
+          /s:${{ github.workspace }}/SonarQube.Analysis.xml
+      - name: Execute dotnet build
+        run: >
+          dotnet build .
+          --configuration ${{ env.CONFIGURATION }}
+      - name: Execute dotnet test
+        run: >
+          dotnet test .
+          --configuration ${{ env.CONFIGURATION }}
+          --results-directory ${{ env.TRX_DIRECTORY }}
+          --settings coverlet.runsettings
+          --collect:"XPlat Code Coverage"
+          --logger:trx
+          --no-restore
+      - name: End Analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        shell: powershell
+        run: >
+          .\.sonar\scanner\dotnet-sonarscanner end 
+          /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+      - name: Parse TRX File
+        if: ${{ always() }}
+        uses: solarisin/trx-parser@dev3
+        id: trx-parser
+        with:
+          TRX_PATH: ${{ env.TRX_DIRECTORY }}
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BADGE_STYLE: emoji

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -35,14 +35,6 @@ jobs:
           --collect:"XPlat Code Coverage"
           --logger:trx
           --no-restore
-      - name: Parse TRX File
-        if: ${{ always() }}
-        uses: solarisin/trx-parser@dev3
-        id: trx-parser
-        with:
-          TRX_PATH: ${{ env.TRX_DIRECTORY }}
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BADGE_STYLE: emoji
   build-test-analyze-debug:
     runs-on: windows-latest
     env:
@@ -112,11 +104,3 @@ jobs:
         run: >
           .\.sonar\scanner\dotnet-sonarscanner end 
           /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
-      - name: Parse TRX File
-        if: ${{ always() }}
-        uses: solarisin/trx-parser@dev3
-        id: trx-parser
-        with:
-          TRX_PATH: ${{ env.TRX_DIRECTORY }}
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BADGE_STYLE: emoji

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 env:
   CI_BUILD: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,8 +12,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]


### PR DESCRIPTION
- ci-pr no longer performs sonarqube eval, and evaluates the trx output itself
- ci-push no longer evaluates trx within the workflow, and allows sonarqube to eval instead